### PR TITLE
Nadodana ruta za dohvacanje informacija o grupama za kolegij

### DIFF
--- a/backend/src/routes/korisnikRoutes.js
+++ b/backend/src/routes/korisnikRoutes.js
@@ -11,7 +11,8 @@ import {
   handleExchangeResponse,
   getColloquium,
   newColloquium,
-  changeSchedule
+  changeSchedule,
+  getGroupAndParticipants
 } from "../viewModels/korisnikViewModel.js";
 import userTypeMiddleWare from "../utils/userTypeMiddleWare.js";
 
@@ -24,6 +25,7 @@ router.post("/sve-grupe/:id?", userTypeMiddleWare, getAllGroups);
 router.post("/todo", userTypeMiddleWare, getToDo);
 router.put("/novi-todo", userTypeMiddleWare, updateToDo);
 
+router.post("/dobavi-sudionike", getGroupAndParticipants);
 router.patch("/promjena-grupe", changeGroup);
 router.post("/zahtjev-razmjene", sendExchangeRequest);
 router.post("/dobavi-zahtjev", getExchangeRequests);


### PR DESCRIPTION
Kao sto naslov kaze.

Evo postman test i odgovor

POST http://localhost:3000/api/korisnik/dobavi-sudionike

{
  "kolegij_naziv": "Osnove programiranja - Vježbe"
}

{
    "success": true,
    "data": [
        {
            "grupa_naziv": "Grupa A",
            "sudionici": [
                "ivan.ivic@univ.com"
            ]
        },
        {
            "grupa_naziv": "Grupa B",
            "sudionici": [
                "ana.klaric@univ.com",
                "filip.horvat@univ.com",
                "andrej.babic@univ.com"
            ]
        },
        {
            "grupa_naziv": "Grupa C",
            "sudionici": [
                "luka.lukic@univ.com",
                "ema.emic@univ.com",
                "dora.novak@univ.com",
                "toni.djuric@univ.com",
                "lea.milinovic@univ.com"
            ]
        }
    ]
}
